### PR TITLE
Script name

### DIFF
--- a/lib/Plack/Middleware/ReverseProxy.pm
+++ b/lib/Plack/Middleware/ReverseProxy.pm
@@ -51,6 +51,9 @@ sub call {
         }
     }
 
+    $env->{SCRIPT_NAME} = $env->{HTTP_X_FORWARDED_SCRIPT_NAME}
+        if $env->{HTTP_X_FORWARDED_SCRIPT_NAME};
+
     $self->app->($env);
 }
 

--- a/t/reverseproxy.t
+++ b/t/reverseproxy.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::Base;
 use lib 't/lib';
-plan tests => 31;
+plan tests => 33;
 
 use Plack::Builder;
 use Plack::Test;
@@ -147,3 +147,10 @@ host: 127.0.0.1:5000
 x-forwarded-host: 192.168.1.2
 x-forwarded-port: 443
 --- secure: 1
+
+=== with HTTP_X_FORWARDED_SCRIPT_NAME
+--- input
+x-forwarded-script-name: /foo
+--- base: http://example.com/foo
+--- uri:  http://example.com/foo/?foo=bar
+


### PR DESCRIPTION
Howdy,

I'm setting up a couple of proxies to point at various apps mounted in the same Plack app. Both proxies will look like they're serving from script name / (or "" I guess) but point to /foo and /bar in the Plack app. So that I can properly generate URIs for things, I'd like to set the X-Forwarded-Script-Name header in my reverse proxy configuration and have Plack::Middleware::ReverseProxy respect it by setting SCRIPT_NAME accordingly. Make sense? I'm following the lead of wsgi (http://www.mail-archive.com/paste-users@pythonpaste.org/msg00178.html) here

After this, I think I'll look at documenting what headers/variables are observed by Plack::Middleware::ReverseProxy and send a pull request for that, too.

Thanks,

David
