### PR TITLE
fix for x-forwarded-proto: http

### DIFF
--- a/lib/Plack/Middleware/ReverseProxy.pm
+++ b/lib/Plack/Middleware/ReverseProxy.pm
@@ -13,7 +13,8 @@ sub call {
     # in apache2 httpd.conf (RequestHeader set X-Forwarded-HTTPS %{HTTPS}s)
     $env->{HTTPS} = $env->{'HTTP_X_FORWARDED_HTTPS'}
         if $env->{'HTTP_X_FORWARDED_HTTPS'};
-    $env->{HTTPS} = 'ON' if $env->{'HTTP_X_FORWARDED_PROTO'};    # Pound
+    $env->{HTTPS} = 'ON'
+        if $env->{'HTTP_X_FORWARDED_PROTO'} && $env->{'HTTP_X_FORWARDED_PROTO'} eq 'https';    # Pound
     $env->{'psgi.url_scheme'}  = 'https' if $env->{HTTPS} && uc $env->{HTTPS} eq 'ON';
     my $default_port = $env->{'psgi.url_scheme'} eq 'https' ? 443 : 80;
 

--- a/t/reverseproxy.t
+++ b/t/reverseproxy.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::Base;
 use lib 't/lib';
-plan tests => 37;
+plan tests => 39;
 
 use Plack::Builder;
 use Plack::Test;
@@ -82,6 +82,13 @@ x-forwarded-proto: https
 --- secure: 1
 --- base: https://example.com:80/
 --- uri:  https://example.com:80/?foo=bar
+
+=== http with HTTP_X_FORWARDED_PROTO
+--- input
+x-forwarded-proto: http
+--- secure: 0
+--- base: http://example.com/
+--- uri:  http://example.com/?foo=bar
 
 === with HTTP_X_FORWARDED_FOR
 --- input


### PR DESCRIPTION
on dotcloud, false detection as https by request header "X-Forwarded-Proto: http".
