### PR TITLE
Edited lib/Plack/Middleware/ReverseProxy.pm via GitHub

### DIFF
--- a/lib/Plack/Middleware/ReverseProxy.pm
+++ b/lib/Plack/Middleware/ReverseProxy.pm
@@ -78,6 +78,8 @@ Plack::Middleware::ReverseProxy - Supports app to run as a reverse proxy backend
 
 =head1 SYNOPSIS
 
+  use Plack::Middleware::ReverseProxy;
+
   builder {
       enable_if { $_[0]->{REMOTE_ADDR} eq '127.0.0.1' } 
           "Plack::Middleware::ReverseProxy";


### PR DESCRIPTION
It's unclear to a novice user like myself that I need to "use" the module first before... It can be assumed that the builder will take care of the module loading.
