### PR TITLE
Allow trailing spaces in HTTP_X_FORWARDED_FOR (eg NetScaler MPX-15000)

### DIFF
--- a/lib/Plack/Middleware/ReverseProxy.pm
+++ b/lib/Plack/Middleware/ReverseProxy.pm
@@ -22,8 +22,8 @@ sub call {
     # If we are running as a backend server, the user will always appear
     # as 127.0.0.1. Select the most recent upstream IP (last in the list)
     if ( $env->{'HTTP_X_FORWARDED_FOR'} ) {
-        my ( $ip, ) = $env->{HTTP_X_FORWARDED_FOR} =~ /([^,\s]+)$/;
-        $env->{REMOTE_ADDR} = $ip;
+        my ( $ip, ) = $env->{HTTP_X_FORWARDED_FOR} =~ /([^,\s]+)\s*$/;
+        $env->{REMOTE_ADDR} = $ip if $ip;
     }
 
     if ( $env->{HTTP_X_FORWARDED_HOST} ) {

--- a/t/reverseproxy.t
+++ b/t/reverseproxy.t
@@ -84,7 +84,7 @@ my @test = (
     uri    => 'http://example.com/?foo=bar',
 },
 'with HTTP_X_FORWARDED_FOR' => {
-    input   => q{x-forwarded-for: 192.168.3.2},
+    input   => q{x-forwarded-for: 192.168.3.2 },
     address => '192.168.3.2',
     base    => 'http://example.com/',
     uri     => 'http://example.com/?foo=bar',


### PR DESCRIPTION
We're using a NetScaler MPX-15000 (running NS9.3: Build 59.5.nc)
and it's adding trailing spaces into the X-Forwarded-For header.

This change allows trailing spaces to be ignored.

(It also prevents REMOTE_ADDR from being set to undef if the
HTTP_X_FORWARDED_FOR parsing fails. That seems like a good idea, but
isn't an important change for me.)
