### PR TITLE
Reverted logic for HTTP_X_FORWARDED_HOST and HTTP_X_FORWARDED_FOR

### DIFF
--- a/lib/Plack/Middleware/ReverseProxy.pm
+++ b/lib/Plack/Middleware/ReverseProxy.pm
@@ -22,7 +22,7 @@ sub call {
     # If we are running as a backend server, the user will always appear
     # as 127.0.0.1. Select the most recent upstream IP (last in the list)
     if ( $env->{'HTTP_X_FORWARDED_FOR'} ) {
-        my ( $ip, ) = $env->{HTTP_X_FORWARDED_FOR} =~ /([^,\s]+)$/;
+        my ( $ip ) = $env->{HTTP_X_FORWARDED_FOR} =~ /^\s*([^,\s]+)/;
         $env->{REMOTE_ADDR} = $ip;
     }
 
@@ -39,7 +39,7 @@ sub call {
             $env->{HTTP_HOST} = $host;
         }
 
-        my ( $host, ) = $env->{HTTP_X_FORWARDED_HOST} =~ /([^,\s]+)$/;
+        my ( $host ) = $env->{HTTP_X_FORWARDED_HOST} =~ /^\s*([^,\s]+)/;
         if ( $host =~ /^(.+):(\d+)$/ ) {
 #            $host = $1;
             $env->{SERVER_PORT} = $2;

--- a/t/reverseproxy.t
+++ b/t/reverseproxy.t
@@ -123,12 +123,12 @@ x-forwarded-port: 1984},
     uri   => 'http://192.168.1.5:1984/?foo=bar',
 },
 'with multiple HTTP_X_FORWARDED_HOST and HTTP_X_FORWARDED_FOR' => {
-    input   => q{x-forwarded-host: outmost.proxy.example.com, middle.proxy.example.com
+    input   => q{x-forwarded-host: host.example.com, outmost.proxy.example.com, middle.proxy.example.com
 x-forwarded-for: 1.2.3.4, 192.168.1.6
 host: 192.168.1.7:5000},
-    address => '192.168.1.6',
-    base    => 'http://middle.proxy.example.com/',
-    uri     => 'http://middle.proxy.example.com/?foo=bar',
+    address => '1.2.3.4',
+    base    => 'http://host.example.com/',
+    uri     => 'http://host.example.com/?foo=bar',
 },
 'normal plackup status' => {
     input => q{host: 127.0.0.1:5000},


### PR DESCRIPTION
The code was using the last item on those headers but the correct one to
use is the first.

For HTTP_X_FORWARDED_FOR, this is reasonable documented:

* https://en.wikipedia.org/wiki/X-Forwarded-For#Format;
* https://metacpan.org/pod/Plack::Middleware::XForwardedFor also uses the
  fist element (ignoring trust for now, which ReverseProxy also ignores).

For HTTP_X_FORWARDED_HOST, I could not get a resonable specification, the best I found was a
test case on the Spring Framework:

https://jira.spring.io/browse/SPR-11140

I do belive that getting the first element is the correct one though, for
consistency with HTTP_X_FORWARDED_FOR.

Another point in favor of using the first element is that both Apache and
nginx add the current host if they find an x-* header in the requests.

Apache handling of X-Forwarded-* starts at
http://svn.apache.org/viewvc/httpd/httpd/trunk/modules/proxy/proxy_util.c?view=markup#l3599
The key line is http://svn.apache.org/viewvc/httpd/httpd/trunk/modules/proxy/proxy_util.c?view=markup#l3626
where the current IP is appended to the current value (spec for apr_table_mergen
is at http://apr.apache.org/docs/apr/1.5/group__apr__tables.html#ga1d50805448114c476cfcd00d5ee3e3a8 ).

nginx logic is at https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_proxy_module.c#L2389
and it also concats the IP.

So on both servers, the first element is the client element.

Obligatory StackOverflow post: http://stackoverflow.com/questions/13111080/what-is-a-full-specification-of-x-forwarded-proto-http-header

Signed-off-by: Pedro Melo <melo@simplicidade.org>